### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/SMU-Projects/2e4b78ed-de6f-45f2-81e6-66382076fa2a/c413b3fe-3d78-4d09-bd62-181be42643ef/_apis/work/boardbadge/05938b9e-6d7e-4dea-843a-1d3c16f7bf64)](https://dev.azure.com/SMU-Projects/2e4b78ed-de6f-45f2-81e6-66382076fa2a/_boards/board/t/c413b3fe-3d78-4d09-bd62-181be42643ef/Microsoft.RequirementCategory)
 # SPM-fiesta


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#8](https://dev.azure.com/SMU-Projects/2e4b78ed-de6f-45f2-81e6-66382076fa2a/_workitems/edit/8). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.